### PR TITLE
Skip dotfiles by default with an option to add them. Also add a help …

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ NEST allows game code and assets to be bundled for easy distribution with the DO
 `./nest [options] -o bundle-file -- [files | directories]`
 
 Options:
-* `-z` will create a bundle
-* `-x` is reserved to unzip a bundle in the future
+* `-h` will display information about usage and the options.
+* `-z` will create a bundle.
+* `-x` is reserved to unzip a bundle in the future.
 * `-v` will print the version of the bundler.
+* `-d` will include files starting with a dot such as `.DS_Store`.
 
 This will create a bundle named "bundle-file" containing the various files and directories specified.
 If the only item to bundle is a directory, the bundle will be created as if the directory was the root.


### PR DESCRIPTION
I've made nest skip dotfiles by default (overridden by the `-d` option) when adding a directory. I haven't added this skip on the files specified as parameters as I assumed that if the user manually types it, they want to add it no matter what.

I've also added a small help menu triggered by the `-h` option.